### PR TITLE
Disable version checking of components

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,6 @@ forceResolve: {
 }
 ```
 
-Example:
-```js
-forceResolve: {
-  'wysihtml5': 'dist/wysihtml5-0.3.0.min.js'
-}
-```
-
 #### options.shim
 Type: `Object`
 Default value: `{}`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Default value: `'./.tmp/scripts/lib.js'`
 
 Path of the destination file.
 
+#### options.checkVersions
+Type: `Boolean`
+Default value: `true`
+
+Simple switch to enable/disable version checking of installed bower components.
+You might want to disable this to make whole process faster, especially with
+bigger number of components.
+
+**Note:** If you are running on Windows and you don't have Git client available
+system wide, you should disable this, otherwise whole process might just fail.
+
 #### options.forceResolve
 Type: `Object`
 Default value: `{}`
@@ -66,6 +77,13 @@ Default value: `{}`
 This object allows to adjust the path to the `main` file of a bower
 package, in case the one specified in the package's `bower.json` is
 faulty. The path should be relative to the package directory.
+
+Example:
+```js
+forceResolve: {
+  'wysihtml5': 'dist/wysihtml5-0.3.0.min.js'
+}
+```
 
 Example:
 ```js

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "bower-resolve": "0.0.3",
+    "bower-resolve": "0.1.0",
     "bower": "~1.2.7",
     "browserify": "~2.35.1",
     "browserify-shim": "~2.0.8",

--- a/tasks/browserify_bower.js
+++ b/tasks/browserify_bower.js
@@ -29,7 +29,8 @@ module.exports = function(grunt) {
       insertGlobals: true,
       detectGlobals: false,
       standalone: "",
-      insertGlobalVars: false
+      insertGlobalVars: false,
+      checkVersions: true
     });
 
     var file = options.file,
@@ -77,6 +78,7 @@ module.exports = function(grunt) {
       return b.bundle(options);
     }
 
+    bowerResolve.offline = !options.checkVersions;
     bowerResolve.init(function () {
 
       bower.commands.list().on('end', function (info) {

--- a/tasks/browserify_bower.js
+++ b/tasks/browserify_bower.js
@@ -81,7 +81,7 @@ module.exports = function(grunt) {
     bowerResolve.offline = !options.checkVersions;
     bowerResolve.init(function () {
 
-      listCfg = {offline: !options.checkVersions}
+      var listCfg = {offline: !options.checkVersions};
       bower.commands.list(null, listCfg).on('end', function (info) {
         Object.keys(info.dependencies).forEach(processBowerDependency);
 

--- a/tasks/browserify_bower.js
+++ b/tasks/browserify_bower.js
@@ -81,7 +81,8 @@ module.exports = function(grunt) {
     bowerResolve.offline = !options.checkVersions;
     bowerResolve.init(function () {
 
-      bower.commands.list().on('end', function (info) {
+      listCfg = {offline: !options.checkVersions}
+      bower.commands.list(null, listCfg).on('end', function (info) {
         Object.keys(info.dependencies).forEach(processBowerDependency);
 
         // Shim other dependencies (outside bower)


### PR DESCRIPTION
This is somewhat dependent on my [pull request to bower-resolve](https://github.com/eugeneware/bower-resolve/pull/1) module. Luckily merging it now doesn't brake anything, so it's pretty safe :)
