### PR TITLE
Emit finish event when done

### DIFF
--- a/tasks/browserify_bower.js
+++ b/tasks/browserify_bower.js
@@ -94,6 +94,7 @@ module.exports = function(grunt) {
         grunt.config.set('browserify.options.external', fromBower.concat(fromExtra));
 
         if (flags.nowrite) {
+          grunt.event.emit('browserifyBower:finish');
           done();
           return;
         }
@@ -102,6 +103,7 @@ module.exports = function(grunt) {
           .pipe(fs.createWriteStream(file))
           .on('finish', function () {
             grunt.log.ok('Wrote %d bower and %d external dependencies to %s', fromBower.length, fromExtra.length, file);
+            grunt.event.emit('browserifyBower:finish');
             done();
           })
           .on('error', function (err) {


### PR DESCRIPTION
Task is setting `browserify.options.external` configuration, which is pretty neat, however if I need some other externals there, things get rather complicated. I am using it like this:

```
grunt.registerTask 'dev', ->
    externalsOption = 'browserify.options.external'
    externals = grunt.config externalsOption

    grunt.event.once 'browserifyBower:finish', ->
        bowerExternals = grunt.config externalsOption
        grunt.config externalsOption, bowerExternals.concat externals
        grunt.task.run 'browserify:signin', 'browserify:main'

    grunt.task.run 'browserifyBower:vendor:nowrite'
```

Maybe there is better way, but this just works for me.
