### PR TITLE
Add option to exclude Bower devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Default value: `[]`
 
 Specifies a pipeline of functions (or modules) through which the browserified bundle will be run. See the [browserify docs themselves](https://github.com/substack/node-browserify#btransformopts-tr) for more on how to use transforms.
 
-### options.includeDevDependencies
+#### options.includeDevDependencies
 Type: `Boolean`
 Default value: `true`
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Default value: `[]`
 
 Specifies a pipeline of functions (or modules) through which the browserified bundle will be run. See the [browserify docs themselves](https://github.com/substack/node-browserify#btransformopts-tr) for more on how to use transforms.
 
+### options.includeDevDependencies
+Type: `Boolean`
+Default value: `true`
+
+Allows for exclusion of `devDependencies`.
 
 ### Usage Examples
 ```js
@@ -148,7 +153,8 @@ grunt.initConfig({
       file: './.tmp/scripts/lib.js',
       forceResolve: {},
       shim: {},
-      transform: []
+      transform: [],
+      includeDevDependencies: true
     }
   },
 })

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "bower": "~1.2.7",
     "browserify": "~2.35.1",
     "browserify-shim": "~2.0.8",
-    "extend": "~1.2.1"
+    "extend": "~1.2.1",
+    "underscore": "^1.6.0"
   }
 }

--- a/tasks/browserify_bower.js
+++ b/tasks/browserify_bower.js
@@ -14,7 +14,8 @@ var path = require('path'),
     browserify = require('browserify'),
     shim = require('browserify-shim'),
     bowerResolve = require('bower-resolve'),
-    bower = require('bower');
+    bower = require('bower'),
+    _ = require('underscore');
 
 module.exports = function(grunt) {
   // Please see the Grunt documentation for more information regarding task
@@ -30,7 +31,8 @@ module.exports = function(grunt) {
       insertGlobals: true,
       detectGlobals: false,
       standalone: "",
-      insertGlobalVars: false
+      insertGlobalVars: false,
+      includeDevDependencies: true
     });
 
     var file = options.file,
@@ -88,7 +90,11 @@ module.exports = function(grunt) {
     bowerResolve.init(function () {
 
       bower.commands.list().on('end', function (info) {
-        Object.keys(info.dependencies).forEach(processBowerDependency);
+        var bowerDependencies = options.includeDevDependencies ?
+          info.dependencies :
+          _.pick(info.dependencies, Object.keys(info.pkgMeta.dependencies));
+        
+        Object.keys(bowerDependencies).forEach(processBowerDependency);
 
         // Shim other dependencies (outside bower)
         Object.keys(options.shim).forEach(function (name) {


### PR DESCRIPTION
It would be nice to have the option to exclude Bower dependencies marked as devDependencies.
